### PR TITLE
0.16 Regression Fixing

### DIFF
--- a/Filtration.ObjectModel/Commands/ItemFilterScript/AddCommentBlockCommand.cs
+++ b/Filtration.ObjectModel/Commands/ItemFilterScript/AddCommentBlockCommand.cs
@@ -15,7 +15,10 @@ namespace Filtration.ObjectModel.Commands.ItemFilterScript
         }
         public void Execute()
         {
-            _newItemFilterBlock = new ItemFilterCommentBlock(_itemFilterScript);
+            _newItemFilterBlock = new ItemFilterCommentBlock(_itemFilterScript)
+            {
+                Comment = string.Empty
+            };
             if (_addAfterItemFilterBlock != null)
             {
                 _itemFilterScript.ItemFilterBlocks.Insert(_itemFilterScript.ItemFilterBlocks.IndexOf(_addAfterItemFilterBlock) + 1, _newItemFilterBlock);

--- a/Filtration/ViewModels/ItemFilterBlockViewModel.cs
+++ b/Filtration/ViewModels/ItemFilterBlockViewModel.cs
@@ -365,7 +365,7 @@ namespace Filtration.ViewModels
                 case "ShBlessed":
                     filePart = "SH22Blessed.wav";
                     break;
-                case "SH22Chaos":
+                case "ShChaos":
                     filePart = "SH22Chaos.wav";
                     break;
                 case "ShDivine":

--- a/Filtration/ViewModels/ItemFilterBlockViewModel.cs
+++ b/Filtration/ViewModels/ItemFilterBlockViewModel.cs
@@ -28,7 +28,6 @@ namespace Filtration.ViewModels
         private readonly IStaticDataService _staticDataService;
         private readonly IReplaceColorsViewModel _replaceColorsViewModel;
         private readonly MediaPlayer _mediaPlayer = new MediaPlayer();
-        private IItemFilterScriptViewModel _parentScriptViewModel;
 
         private bool _displaySettingsPopupOpen;
         private bool _isExpanded;
@@ -39,17 +38,8 @@ namespace Filtration.ViewModels
             _staticDataService = staticDataService;
             _replaceColorsViewModel = replaceColorsViewModel;
 
-            CopyBlockCommand = new RelayCommand(OnCopyBlockCommand);
-            PasteBlockCommand = new RelayCommand(OnPasteBlockCommand);
             CopyBlockStyleCommand = new RelayCommand(OnCopyBlockStyleCommand);
             PasteBlockStyleCommand = new RelayCommand(OnPasteBlockStyleCommand);
-            AddBlockCommand = new RelayCommand(OnAddBlockCommand);
-            AddSectionCommand = new RelayCommand(OnAddSectionCommand);
-            DeleteBlockCommand = new RelayCommand(OnDeleteBlockCommand);
-            MoveBlockUpCommand = new RelayCommand(OnMoveBlockUpCommand);
-            MoveBlockDownCommand = new RelayCommand(OnMoveBlockDownCommand);
-            MoveBlockToTopCommand = new RelayCommand(OnMoveBlockToTopCommand);
-            MoveBlockToBottomCommand = new RelayCommand(OnMoveBlockToBottomCommand);
             ReplaceColorsCommand = new RelayCommand(OnReplaceColorsCommand);
             AddFilterBlockItemCommand = new RelayCommand<Type>(OnAddFilterBlockItemCommand);
             ToggleBlockActionCommand = new RelayCommand(OnToggleBlockActionCommand);
@@ -82,17 +72,8 @@ namespace Filtration.ViewModels
             base.Initialise(itemFilterBlock, parentScriptViewModel);
         }
 
-        public RelayCommand CopyBlockCommand { get; }
-        public RelayCommand PasteBlockCommand { get; }
         public RelayCommand CopyBlockStyleCommand { get; }
         public RelayCommand PasteBlockStyleCommand { get; }
-        public RelayCommand AddBlockCommand { get; }
-        public RelayCommand AddSectionCommand { get; }
-        public RelayCommand DeleteBlockCommand { get; }
-        public RelayCommand MoveBlockUpCommand { get; }
-        public RelayCommand MoveBlockDownCommand { get; }
-        public RelayCommand MoveBlockToTopCommand { get; }
-        public RelayCommand MoveBlockToBottomCommand { get; }
         public RelayCommand ToggleBlockActionCommand { get; }
         public RelayCommand ReplaceColorsCommand { get; }
         public RelayCommand<Type> AddFilterBlockItemCommand { get; }

--- a/Filtration/ViewModels/ItemFilterBlockViewModelBase.cs
+++ b/Filtration/ViewModels/ItemFilterBlockViewModelBase.cs
@@ -1,6 +1,7 @@
 using System;
 using Filtration.ObjectModel;
 using GalaSoft.MvvmLight;
+using GalaSoft.MvvmLight.CommandWpf;
 
 namespace Filtration.ViewModels
 {
@@ -16,14 +17,40 @@ namespace Filtration.ViewModels
     {
         private bool _isDirty;
 
+        public ItemFilterBlockViewModelBase()
+        {
+            CopyBlockCommand = new RelayCommand(OnCopyBlockCommand);
+            PasteBlockCommand = new RelayCommand(OnPasteBlockCommand);
+            AddBlockCommand = new RelayCommand(OnAddBlockCommand);
+            AddSectionCommand = new RelayCommand(OnAddSectionCommand);
+            DeleteBlockCommand = new RelayCommand(OnDeleteBlockCommand);
+            MoveBlockUpCommand = new RelayCommand(OnMoveBlockUpCommand);
+            MoveBlockDownCommand = new RelayCommand(OnMoveBlockDownCommand);
+            MoveBlockToTopCommand = new RelayCommand(OnMoveBlockToTopCommand);
+            MoveBlockToBottomCommand = new RelayCommand(OnMoveBlockToBottomCommand);
+        }
+
+
         public virtual void Initialise(IItemFilterBlockBase itemfilterBlock, IItemFilterScriptViewModel itemFilterScriptViewModel)
         {
             BaseBlock = itemfilterBlock;
+            _parentScriptViewModel = itemFilterScriptViewModel;
         }
 
         public event EventHandler BlockBecameDirty;
 
         public IItemFilterBlockBase BaseBlock { get; protected set; }
+        public IItemFilterScriptViewModel _parentScriptViewModel;
+
+        public RelayCommand CopyBlockCommand { get; }
+        public RelayCommand PasteBlockCommand { get; }
+        public RelayCommand AddBlockCommand { get; }
+        public RelayCommand AddSectionCommand { get; }
+        public RelayCommand DeleteBlockCommand { get; }
+        public RelayCommand MoveBlockUpCommand { get; }
+        public RelayCommand MoveBlockDownCommand { get; }
+        public RelayCommand MoveBlockToTopCommand { get; }
+        public RelayCommand MoveBlockToBottomCommand { get; }
         
         public bool IsDirty
         {
@@ -37,6 +64,51 @@ namespace Filtration.ViewModels
                     BlockBecameDirty?.Invoke(this, EventArgs.Empty);
                 }
             }
+        }
+
+        private void OnCopyBlockCommand()
+        {
+            _parentScriptViewModel.CopyBlock(this);
+        }
+
+        private void OnPasteBlockCommand()
+        {
+            _parentScriptViewModel.PasteBlock(this);
+        }
+
+        private void OnAddBlockCommand()
+        {
+            _parentScriptViewModel.AddBlock(this);
+        }
+
+        private void OnAddSectionCommand()
+        {
+            _parentScriptViewModel.AddCommentBlock(this);
+        }
+
+        private void OnDeleteBlockCommand()
+        {
+            _parentScriptViewModel.DeleteBlock(this);
+        }
+
+        private void OnMoveBlockUpCommand()
+        {
+            _parentScriptViewModel.MoveBlockUp(this);
+        }
+
+        private void OnMoveBlockDownCommand()
+        {
+            _parentScriptViewModel.MoveBlockDown(this);
+        }
+
+        private void OnMoveBlockToTopCommand()
+        {
+            _parentScriptViewModel.MoveBlockToTop(this);
+        }
+
+        private void OnMoveBlockToBottomCommand()
+        {
+            _parentScriptViewModel.MoveBlockToBottom(this);
         }
     }
 }

--- a/Filtration/ViewModels/ItemFilterCommentBlockViewModel.cs
+++ b/Filtration/ViewModels/ItemFilterCommentBlockViewModel.cs
@@ -29,8 +29,12 @@ namespace Filtration.ViewModels
             }
             set
             {
-                ItemFilterCommentBlock.Comment = value;
-                RaisePropertyChanged();
+                if (ItemFilterCommentBlock.Comment != value)
+                {
+                    ItemFilterCommentBlock.Comment = value;
+                    IsDirty = true;
+                    RaisePropertyChanged();
+                }
             }
         }
     }

--- a/Filtration/ViewModels/ItemFilterCommentBlockViewModel.cs
+++ b/Filtration/ViewModels/ItemFilterCommentBlockViewModel.cs
@@ -25,7 +25,7 @@ namespace Filtration.ViewModels
             MoveBlockToTopCommand = new RelayCommand(OnMoveBlockToTopCommand);
             MoveBlockToBottomCommand = new RelayCommand(OnMoveBlockToBottomCommand);
         }
-
+        
         public RelayCommand CopyBlockCommand { get; }
         public RelayCommand PasteBlockCommand { get; }
         public RelayCommand AddBlockCommand { get; }
@@ -47,7 +47,17 @@ namespace Filtration.ViewModels
 
         public IItemFilterCommentBlock ItemFilterCommentBlock { get; private set; }
 
-        public string Comment => ItemFilterCommentBlock.Comment;
+        public string Comment
+        {
+            get
+            {
+                return ItemFilterCommentBlock.Comment;
+            }
+            set
+            {
+                ItemFilterCommentBlock.Comment = value;
+            }
+        }
 
         private void OnCopyBlockCommand()
         {

--- a/Filtration/ViewModels/ItemFilterCommentBlockViewModel.cs
+++ b/Filtration/ViewModels/ItemFilterCommentBlockViewModel.cs
@@ -1,5 +1,4 @@
 ﻿using Filtration.ObjectModel;
-using GalaSoft.MvvmLight.CommandWpf;
 
 namespace Filtration.ViewModels
 {
@@ -11,31 +10,6 @@ namespace Filtration.ViewModels
 
     internal class ItemFilterCommentBlockViewModel : ItemFilterBlockViewModelBase, IItemFilterCommentBlockViewModel
     {
-        private IItemFilterScriptViewModel _parentScriptViewModel;
-
-        public ItemFilterCommentBlockViewModel()
-        {
-            CopyBlockCommand = new RelayCommand(OnCopyBlockCommand);
-            PasteBlockCommand = new RelayCommand(OnPasteBlockCommand);
-            AddBlockCommand = new RelayCommand(OnAddBlockCommand);
-            AddSectionCommand = new RelayCommand(OnAddSectionCommand);
-            DeleteBlockCommand = new RelayCommand(OnDeleteBlockCommand);
-            MoveBlockUpCommand = new RelayCommand(OnMoveBlockUpCommand);
-            MoveBlockDownCommand = new RelayCommand(OnMoveBlockDownCommand);
-            MoveBlockToTopCommand = new RelayCommand(OnMoveBlockToTopCommand);
-            MoveBlockToBottomCommand = new RelayCommand(OnMoveBlockToBottomCommand);
-        }
-        
-        public RelayCommand CopyBlockCommand { get; }
-        public RelayCommand PasteBlockCommand { get; }
-        public RelayCommand AddBlockCommand { get; }
-        public RelayCommand AddSectionCommand { get; }
-        public RelayCommand DeleteBlockCommand { get; }
-        public RelayCommand MoveBlockUpCommand { get; }
-        public RelayCommand MoveBlockDownCommand { get; }
-        public RelayCommand MoveBlockToTopCommand { get; }
-        public RelayCommand MoveBlockToBottomCommand { get; }
-
         public override void Initialise(IItemFilterBlockBase itemfilterBlock, IItemFilterScriptViewModel itemFilterScriptViewModel)
         {
             _parentScriptViewModel = itemFilterScriptViewModel;
@@ -56,52 +30,8 @@ namespace Filtration.ViewModels
             set
             {
                 ItemFilterCommentBlock.Comment = value;
+                RaisePropertyChanged();
             }
-        }
-
-        private void OnCopyBlockCommand()
-        {
-            _parentScriptViewModel.CopyBlock(this);
-        }
-
-        private void OnPasteBlockCommand()
-        {
-            _parentScriptViewModel.PasteBlock(this);
-        }
-
-        private void OnAddBlockCommand()
-        {
-            _parentScriptViewModel.AddBlock(this);
-        }
-
-        private void OnAddSectionCommand()
-        {
-            _parentScriptViewModel.AddCommentBlock(this);
-        }
-
-        private void OnDeleteBlockCommand()
-        {
-            _parentScriptViewModel.DeleteBlock(this);
-        }
-
-        private void OnMoveBlockUpCommand()
-        {
-            _parentScriptViewModel.MoveBlockUp(this);
-        }
-
-        private void OnMoveBlockDownCommand()
-        {
-            _parentScriptViewModel.MoveBlockDown(this);
-        }
-
-        private void OnMoveBlockToTopCommand()
-        {
-            _parentScriptViewModel.MoveBlockToTop(this);
-        }
-
-        private void OnMoveBlockToBottomCommand()
-        {
-            _parentScriptViewModel.MoveBlockToBottom(this);
         }
     }
 }

--- a/Filtration/ViewModels/ItemFilterCommentBlockViewModel.cs
+++ b/Filtration/ViewModels/ItemFilterCommentBlockViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using Filtration.ObjectModel;
+using GalaSoft.MvvmLight.CommandWpf;
 
 namespace Filtration.ViewModels
 {
@@ -10,12 +11,34 @@ namespace Filtration.ViewModels
 
     internal class ItemFilterCommentBlockViewModel : ItemFilterBlockViewModelBase, IItemFilterCommentBlockViewModel
     {
+        private IItemFilterScriptViewModel _parentScriptViewModel;
+
         public ItemFilterCommentBlockViewModel()
         {
+            CopyBlockCommand = new RelayCommand(OnCopyBlockCommand);
+            PasteBlockCommand = new RelayCommand(OnPasteBlockCommand);
+            AddBlockCommand = new RelayCommand(OnAddBlockCommand);
+            AddSectionCommand = new RelayCommand(OnAddSectionCommand);
+            DeleteBlockCommand = new RelayCommand(OnDeleteBlockCommand);
+            MoveBlockUpCommand = new RelayCommand(OnMoveBlockUpCommand);
+            MoveBlockDownCommand = new RelayCommand(OnMoveBlockDownCommand);
+            MoveBlockToTopCommand = new RelayCommand(OnMoveBlockToTopCommand);
+            MoveBlockToBottomCommand = new RelayCommand(OnMoveBlockToBottomCommand);
         }
+
+        public RelayCommand CopyBlockCommand { get; }
+        public RelayCommand PasteBlockCommand { get; }
+        public RelayCommand AddBlockCommand { get; }
+        public RelayCommand AddSectionCommand { get; }
+        public RelayCommand DeleteBlockCommand { get; }
+        public RelayCommand MoveBlockUpCommand { get; }
+        public RelayCommand MoveBlockDownCommand { get; }
+        public RelayCommand MoveBlockToTopCommand { get; }
+        public RelayCommand MoveBlockToBottomCommand { get; }
 
         public override void Initialise(IItemFilterBlockBase itemfilterBlock, IItemFilterScriptViewModel itemFilterScriptViewModel)
         {
+            _parentScriptViewModel = itemFilterScriptViewModel;
             ItemFilterCommentBlock = itemfilterBlock as IItemFilterCommentBlock;
             BaseBlock = ItemFilterCommentBlock;
 
@@ -25,5 +48,50 @@ namespace Filtration.ViewModels
         public IItemFilterCommentBlock ItemFilterCommentBlock { get; private set; }
 
         public string Comment => ItemFilterCommentBlock.Comment;
+
+        private void OnCopyBlockCommand()
+        {
+            _parentScriptViewModel.CopyBlock(this);
+        }
+
+        private void OnPasteBlockCommand()
+        {
+            _parentScriptViewModel.PasteBlock(this);
+        }
+
+        private void OnAddBlockCommand()
+        {
+            _parentScriptViewModel.AddBlock(this);
+        }
+
+        private void OnAddSectionCommand()
+        {
+            _parentScriptViewModel.AddCommentBlock(this);
+        }
+
+        private void OnDeleteBlockCommand()
+        {
+            _parentScriptViewModel.DeleteBlock(this);
+        }
+
+        private void OnMoveBlockUpCommand()
+        {
+            _parentScriptViewModel.MoveBlockUp(this);
+        }
+
+        private void OnMoveBlockDownCommand()
+        {
+            _parentScriptViewModel.MoveBlockDown(this);
+        }
+
+        private void OnMoveBlockToTopCommand()
+        {
+            _parentScriptViewModel.MoveBlockToTop(this);
+        }
+
+        private void OnMoveBlockToBottomCommand()
+        {
+            _parentScriptViewModel.MoveBlockToBottom(this);
+        }
     }
 }

--- a/Filtration/Views/ItemFilterCommentBlockView.xaml
+++ b/Filtration/Views/ItemFilterCommentBlockView.xaml
@@ -56,7 +56,7 @@
                     <MenuItem Header="Add Block" Command="{Binding AddBlockCommand}" Icon="{StaticResource AddBlockIcon}" />
                     <MenuItem Header="Add Section" Command="{Binding AddSectionCommand}" Icon="{StaticResource AddSectionIcon}" />
                     <Separator />
-                    <MenuItem Header="Delete Section" Command="{Binding Data.DeleteBlockCommand, Source={StaticResource Proxy}}" Icon="{StaticResource DeleteIcon}" />
+                    <MenuItem Header="Delete Section" Command="{Binding DeleteBlockCommand}" Icon="{StaticResource DeleteIcon}" />
                     <Separator />
                     <MenuItem Header="Move Section To Top" Command="{Binding MoveBlockToTopCommand}" Icon="{StaticResource MoveToTopIcon}" />
                     <MenuItem Header="Move Section Up" Command="{Binding MoveBlockUpCommand}" Icon="{StaticResource MoveUpIcon}" />
@@ -76,7 +76,7 @@
                     <ColumnDefinition Width="Auto" />
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
-                <TextBox Grid.Column ="0" Text="{Binding Comment, UpdateSourceTrigger=PropertyChanged, Mode=OneWay}" VerticalAlignment="Center" TextWrapping="Wrap" MinWidth="150"/>
+                <TextBox Grid.Column ="0" Text="{Binding Comment, UpdateSourceTrigger=PropertyChanged, Mode=TwoWay}" VerticalAlignment="Center" TextWrapping="Wrap" MinWidth="150"/>
             </Grid>
         </Border>
     </Grid>

--- a/Filtration/Views/ItemFilterCommentBlockView.xaml
+++ b/Filtration/Views/ItemFilterCommentBlockView.xaml
@@ -4,16 +4,47 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:viewModels="clr-namespace:Filtration.ViewModels"
+             xmlns:views="clr-namespace:Filtration.Views"
+             xmlns:converters="clr-namespace:Filtration.Converters"
              d:DataContext="{d:DesignInstance Type=viewModels:ItemFilterCommentBlockViewModel}"
              mc:Ignorable="d" 
              d:DesignHeight="50" d:DesignWidth="300">
     <UserControl.Resources>
-        <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MetroTextBox}">
-            <Style.Setters>
-                <Setter Property="BorderBrush" Value="Transparent" />
-                <Setter Property="Background" Value="Transparent" />
-            </Style.Setters>
-        </Style>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary>
+                    <views:BindingProxy x:Key="Proxy" Data="{Binding}" />
+                    <converters:BlockGroupAdvancedFillColorConverter x:Key="BlockGroupAdvancedFillColorConverter" />
+                    <Style TargetType="{x:Type ContentPresenter}" x:Key="BlockItemFadeInStyle">
+                        <Setter Property="LayoutTransform">
+                            <Setter.Value>
+                                <ScaleTransform x:Name="transform" />
+                            </Setter.Value>
+                        </Setter>
+                        <Style.Triggers>
+                            <EventTrigger RoutedEvent="Loaded">
+                                <EventTrigger.Actions>
+                                    <BeginStoryboard>
+                                        <Storyboard>
+                                            <DoubleAnimation Storyboard.TargetProperty="Opacity" From="0" To="1" Duration="0:0:0.5" />
+                                        </Storyboard>
+                                    </BeginStoryboard>
+                                </EventTrigger.Actions>
+                            </EventTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </ResourceDictionary>
+                <ResourceDictionary>
+                <Style TargetType="{x:Type TextBox}" BasedOn="{StaticResource MetroTextBox}">
+                    <Style.Setters>
+                        <Setter Property="BorderBrush" Value="Transparent" />
+                        <Setter Property="Background" Value="Transparent" />
+                    </Style.Setters>
+                </Style>
+                </ResourceDictionary>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+        
     </UserControl.Resources>
     <Grid>
         <Grid.ContextMenu>
@@ -25,7 +56,7 @@
                     <MenuItem Header="Add Block" Command="{Binding AddBlockCommand}" Icon="{StaticResource AddBlockIcon}" />
                     <MenuItem Header="Add Section" Command="{Binding AddSectionCommand}" Icon="{StaticResource AddSectionIcon}" />
                     <Separator />
-                    <MenuItem Header="Delete Section" Command="{Binding DeleteBlockCommand}" Icon="{StaticResource DeleteIcon}" />
+                    <MenuItem Header="Delete Section" Command="{Binding Data.DeleteBlockCommand, Source={StaticResource Proxy}}" Icon="{StaticResource DeleteIcon}" />
                     <Separator />
                     <MenuItem Header="Move Section To Top" Command="{Binding MoveBlockToTopCommand}" Icon="{StaticResource MoveToTopIcon}" />
                     <MenuItem Header="Move Section Up" Command="{Binding MoveBlockUpCommand}" Icon="{StaticResource MoveUpIcon}" />


### PR DESCRIPTION
Version 0.16 saw a lot of major changes to the codebase, so it wasn't without regression. The goal of this pull request is to fix all of these regressions.

- [x] Clicking the "Add Section" button results in a crash.
- [x] Edits to comments within their view are not properly updating the underlying model, resulting in value resets.
- [x] Right clicking a section and choosing "Delete Section" results in no changes.
- [X] The "ShChaos" sound does not work.
- [ ] A section cannot precede the very first block within an item filter anymore.
- [x] Changes to comments do not put the filter into the unsaved state.
- [ ] Deleting and adding both Blocks and Sections does not put the filter into the unsaved state.

The first three are more in your domain @ben-wallis, but I'll be looking into each to see if I can figure out what's going on. One thing worth noting is that these issues were caused by the last few commits, as they weren't a thing in my branch.