### PR TITLE
Fix the reading of CustomAlertSounds containing path separators.

### DIFF
--- a/Filtration.Parser.Tests/Services/TestItemFilterBlockTranslator.cs
+++ b/Filtration.Parser.Tests/Services/TestItemFilterBlockTranslator.cs
@@ -1272,6 +1272,41 @@ namespace Filtration.Parser.Tests.Services
         }
 
         [Test]
+        public void TranslateStringToItemFilterBlock_SpecificTest_2()
+        {
+            // Arrange
+            var inputString = @"#8#" + Environment.NewLine +
+                              "Hide " + Environment.NewLine +
+                              "Rarity Magic " + Environment.NewLine +
+                              "DropLevel >= 67" + Environment.NewLine +
+                              "BaseType \"Sorcerer Boots\"" + Environment.NewLine +
+                              "Rarity Magic " + Environment.NewLine +
+                              "SetFontSize 26" + Environment.NewLine +
+                              "SetBackgroundColor 0 20 0\"";
+
+
+            _testUtility.TestBlock.Enabled = false;
+            _testUtility.TestBlock.BlockItems.Add(new WidthBlockItem(FilterPredicateOperator.Equal, 4));
+
+            // Act
+            var result = _testUtility.Translator.TranslateStringToItemFilterBlock(inputString, _testUtility.MockItemFilterScript);
+
+            // Assert
+            Assert.AreEqual(1, result.BlockItems.Count(b => b is ActionBlockItem));
+            var actionBlockItem = result.BlockItems.OfType<ActionBlockItem>().First();
+            Assert.AreEqual(BlockAction.Hide, actionBlockItem.Action);
+
+            Assert.AreEqual(1, result.BlockItems.Count(b => b is DropLevelBlockItem));
+            var droplevelBlockItem = result.BlockItems.OfType<DropLevelBlockItem>().First();
+            Assert.AreEqual(67, droplevelBlockItem.FilterPredicate.PredicateOperand);
+            Assert.AreEqual(FilterPredicateOperator.GreaterThanOrEqual, droplevelBlockItem.FilterPredicate.PredicateOperator);
+
+            Assert.AreEqual(1, result.BlockItems.Count(b => b is RarityBlockItem));
+            var rarityBlockItem = result.BlockItems.OfType<RarityBlockItem>().First();
+            Assert.AreEqual(ItemRarity.Magic, (ItemRarity)rarityBlockItem.FilterPredicate.PredicateOperand);
+        }
+
+        [Test]
         public void TranslateStringToItemFilterBlock_CustomSoundDocumentsFile()
         {
             // Arrange
@@ -1349,41 +1384,6 @@ namespace Filtration.Parser.Tests.Services
             Assert.AreEqual(1, result.BlockItems.Count(b => b is CustomSoundBlockItem));
             var customSoundBlockItem = result.BlockItems.OfType<CustomSoundBlockItem>().First();
             Assert.AreEqual("C:\\Sounds/test.mp3", customSoundBlockItem.Value);
-        }
-
-        [Test]
-        public void TranslateStringToItemFilterBlock_SpecificTest_2()
-        {
-            // Arrange
-            var inputString = @"#8#" + Environment.NewLine +
-                              "Hide " + Environment.NewLine +
-                              "Rarity Magic " + Environment.NewLine +
-                              "DropLevel >= 67" + Environment.NewLine +
-                              "BaseType \"Sorcerer Boots\"" + Environment.NewLine +
-                              "Rarity Magic " + Environment.NewLine +
-                              "SetFontSize 26" + Environment.NewLine +
-                              "SetBackgroundColor 0 20 0\"";
-
-
-            _testUtility.TestBlock.Enabled = false;
-            _testUtility.TestBlock.BlockItems.Add(new WidthBlockItem(FilterPredicateOperator.Equal, 4));
-
-            // Act
-            var result = _testUtility.Translator.TranslateStringToItemFilterBlock(inputString, _testUtility.MockItemFilterScript);
-
-            // Assert
-            Assert.AreEqual(1, result.BlockItems.Count(b => b is ActionBlockItem));
-            var actionBlockItem = result.BlockItems.OfType<ActionBlockItem>().First();
-            Assert.AreEqual(BlockAction.Hide, actionBlockItem.Action);
-
-            Assert.AreEqual(1, result.BlockItems.Count(b => b is DropLevelBlockItem));
-            var droplevelBlockItem = result.BlockItems.OfType<DropLevelBlockItem>().First();
-            Assert.AreEqual(67, droplevelBlockItem.FilterPredicate.PredicateOperand);
-            Assert.AreEqual(FilterPredicateOperator.GreaterThanOrEqual, droplevelBlockItem.FilterPredicate.PredicateOperator);
-
-            Assert.AreEqual(1, result.BlockItems.Count(b => b is RarityBlockItem));
-            var rarityBlockItem = result.BlockItems.OfType<RarityBlockItem>().First();
-            Assert.AreEqual(ItemRarity.Magic, (ItemRarity)rarityBlockItem.FilterPredicate.PredicateOperand);
         }
 
         [Test]

--- a/Filtration.Parser.Tests/Services/TestItemFilterBlockTranslator.cs
+++ b/Filtration.Parser.Tests/Services/TestItemFilterBlockTranslator.cs
@@ -94,7 +94,7 @@ namespace Filtration.Parser.Tests.Services
             // Arrange
             var inputString = "HideDisabled" + Environment.NewLine +
                               "    ItemLevel >= 55";
-            
+
             // Act
             var result = _testUtility.Translator.TranslateStringToItemFilterBlock(inputString, _testUtility.MockItemFilterScript);
 
@@ -793,7 +793,7 @@ namespace Filtration.Parser.Tests.Services
                               "    SetTextColor 255 20 100 # Rare Item Text";
             var testComponent = new ColorThemeComponent(ThemeComponentType.TextColor, "Rare Item Text", new Color { R = 255, G = 20, B = 100});
             var testInputThemeComponentCollection = new ThemeComponentCollection { testComponent };
-            
+
             // Act
             var result = _testUtility.Translator.TranslateStringToItemFilterBlock(inputString, Mock.Of<IItemFilterScript>(i => i.ItemFilterScriptSettings.ThemeComponentCollection == testInputThemeComponentCollection));
 
@@ -1044,7 +1044,7 @@ namespace Filtration.Parser.Tests.Services
 
             var fontSizeblockItem = result.BlockItems.OfType<FontSizeBlockItem>().First();
             Assert.AreEqual(50, fontSizeblockItem.Value);
-            
+
             Assert.AreEqual(0, result.BlockItems.OfType<SoundBlockItem>().Count());
 
             var disableDropSoundBlockItem = result.BlockItems.OfType<DisableDropSoundBlockItem>().First();
@@ -1087,9 +1087,9 @@ namespace Filtration.Parser.Tests.Services
             // Arrange
 
             var inputString = "Show" + Environment.NewLine +
-                              "    ItemLevel >= 70" + Environment.NewLine + 
-                              "    ItemLevel <= 80" + Environment.NewLine + 
-                              "    Quality = 15" + Environment.NewLine + 
+                              "    ItemLevel >= 70" + Environment.NewLine +
+                              "    ItemLevel <= 80" + Environment.NewLine +
+                              "    Quality = 15" + Environment.NewLine +
                               "    Quality < 17";
 
             // Act
@@ -1150,7 +1150,7 @@ namespace Filtration.Parser.Tests.Services
             var blockItem = result.BlockItems.OfType<FontSizeBlockItem>().First();
             Assert.AreEqual(27, blockItem.Value);
         }
-        
+
         [Test]
         public void TranslateStringToItemFilterBlock_MultipleSoundItems_OnlyLastOneUsed()
         {
@@ -1272,6 +1272,86 @@ namespace Filtration.Parser.Tests.Services
         }
 
         [Test]
+        public void TranslateStringToItemFilterBlock_CustomSoundDocumentsFile()
+        {
+            // Arrange
+            var inputString = @"Show" + Environment.NewLine +
+                              "CustomAlertSound \"test.mp3\"";
+
+            // Act
+            var result = _testUtility.Translator.TranslateStringToItemFilterBlock(inputString, _testUtility.MockItemFilterScript);
+
+            // Assert
+            Assert.AreEqual(1, result.BlockItems.Count(b => b is CustomSoundBlockItem));
+            var customSoundBlockItem = result.BlockItems.OfType<CustomSoundBlockItem>().First();
+            Assert.AreEqual("test.mp3", customSoundBlockItem.Value);
+        }
+
+        [Test]
+        public void TranslateStringToItemFilterBlock_CustomSoundDocumentsRelativeFile()
+        {
+            // Arrange
+            var inputString = @"Show" + Environment.NewLine +
+                              "CustomAlertSound \"Sounds\test.mp3\"";
+
+            // Act
+            var result = _testUtility.Translator.TranslateStringToItemFilterBlock(inputString, _testUtility.MockItemFilterScript);
+
+            // Assert
+            Assert.AreEqual(1, result.BlockItems.Count(b => b is CustomSoundBlockItem));
+            var customSoundBlockItem = result.BlockItems.OfType<CustomSoundBlockItem>().First();
+            Assert.AreEqual("Sounds\test.mp3", customSoundBlockItem.Value);
+        }
+
+        [Test]
+        public void TranslateStringToItemFilterBlock_CustomSoundFullBackSlashPath()
+        {
+            // Arrange
+            var inputString = @"Show" + Environment.NewLine +
+                              "CustomAlertSound \"C:\\Sounds\\test.mp3\"";
+
+            // Act
+            var result = _testUtility.Translator.TranslateStringToItemFilterBlock(inputString, _testUtility.MockItemFilterScript);
+
+            // Assert
+            Assert.AreEqual(1, result.BlockItems.Count(b => b is CustomSoundBlockItem));
+            var customSoundBlockItem = result.BlockItems.OfType<CustomSoundBlockItem>().First();
+            Assert.AreEqual("C:\\Sounds\\test.mp3", customSoundBlockItem.Value);
+        }
+
+        [Test]
+        public void TranslateStringToItemFilterBlock_CustomSoundFullForwardSlashPath()
+        {
+            // Arrange
+            var inputString = @"Show" + Environment.NewLine +
+                              "CustomAlertSound \"C:/Sounds/test.mp3\"";
+
+            //Act
+            var result = _testUtility.Translator.TranslateStringToItemFilterBlock(inputString, _testUtility.MockItemFilterScript);
+
+            // Assert
+            Assert.AreEqual(1, result.BlockItems.Count(b => b is CustomSoundBlockItem));
+            var customSoundBlockItem = result.BlockItems.OfType<CustomSoundBlockItem>().First();
+            Assert.AreEqual("C:/Sounds/test.mp3", customSoundBlockItem.Value);
+        }
+
+        [Test]
+        public void TranslateStringToItemFilterBlock_CustomSoundFullMixedPath()
+        {
+            // Arrange
+            var inputString = @"Show" + Environment.NewLine +
+                              "CustomAlertSound \"C:\\Sounds/test.mp3\"";
+
+            // Act
+            var result = _testUtility.Translator.TranslateStringToItemFilterBlock(inputString, _testUtility.MockItemFilterScript);
+
+            // Assert
+            Assert.AreEqual(1, result.BlockItems.Count(b => b is CustomSoundBlockItem));
+            var customSoundBlockItem = result.BlockItems.OfType<CustomSoundBlockItem>().First();
+            Assert.AreEqual("C:\\Sounds/test.mp3", customSoundBlockItem.Value);
+        }
+
+        [Test]
         public void TranslateStringToItemFilterBlock_SpecificTest_2()
         {
             // Arrange
@@ -1326,7 +1406,7 @@ namespace Filtration.Parser.Tests.Services
         {
             // Arrange
             var expectedResult = "Show # Child 1 Block Group - Child 2 Block Group";
-            
+
             var rootBlockGroup = new ItemFilterBlockGroup("Root Block Group", null);
             var child1BlockGroup = new ItemFilterBlockGroup("Child 1 Block Group", rootBlockGroup);
             var child2BlockGroup = new ItemFilterBlockGroup("Child 2 Block Group", child1BlockGroup);
@@ -1851,7 +1931,7 @@ namespace Filtration.Parser.Tests.Services
         {
             // Arrange
             var expectedResult = "Show" + Environment.NewLine +
-                                 "    ItemLevel > 56" + Environment.NewLine + 
+                                 "    ItemLevel > 56" + Environment.NewLine +
                                  "    ItemLevel >= 45" + Environment.NewLine +
                                  "    ItemLevel < 100";
 
@@ -1893,7 +1973,7 @@ namespace Filtration.Parser.Tests.Services
             // Arrange
             var expectedResult = "#Show" + Environment.NewLine +
                                  "#    Width = 4";
-                                 
+
 
             _testUtility.TestBlock.Enabled = false;
             _testUtility.TestBlock.BlockItems.Add(new WidthBlockItem(FilterPredicateOperator.Equal, 4));
@@ -2008,7 +2088,7 @@ namespace Filtration.Parser.Tests.Services
 
             // Act
             _testUtility.Translator.ReplaceAudioVisualBlockItemsFromString(testInputBlockItems, testInputString);
-            
+
             // Assert
             var textColorBlockItem = testInputBlockItems.First(b => b is TextColorBlockItem) as TextColorBlockItem;
             Assert.IsNotNull(textColorBlockItem);
@@ -2083,7 +2163,7 @@ namespace Filtration.Parser.Tests.Services
             // Arrange
             var testInputString = "SetTextColor 240 200 150 # Rarest Currency" + Environment.NewLine +
                                   "SetBackgroundColor 0 0 0 # Rarest Currency Background" + Environment.NewLine +
-                                  "SetBorderColor 255 255 255 # Rarest Currency Border" + Environment.NewLine + 
+                                  "SetBorderColor 255 255 255 # Rarest Currency Border" + Environment.NewLine +
                                   "PlayAlertSound 7 280";
 
             var testInputBlockItems = new ObservableCollection<IItemFilterBlockItem>();
@@ -2129,9 +2209,9 @@ namespace Filtration.Parser.Tests.Services
             // Arrange
             var testInputString = "SetTextColor 240 200 150 # Rarest Currency" + Environment.NewLine +
                                   "SetBackgroundColor 0 0 0 # Rarest Currency Background" + Environment.NewLine +
-                                  "SetBorderColor 255 255 255 # Rarest Currency Border" + Environment.NewLine + 
+                                  "SetBorderColor 255 255 255 # Rarest Currency Border" + Environment.NewLine +
                                   "PlayAlertSound 7 280";
-            
+
             var testInputBlockItems = new ObservableCollection<IItemFilterBlockItem>();
 
             // Act
@@ -2201,9 +2281,9 @@ namespace Filtration.Parser.Tests.Services
             _testUtility.Translator.ReplaceAudioVisualBlockItemsFromString(testInputBlockItems, testInputString);
 
             // Assert
-            
+
         }
-        
+
         private class ItemFilterBlockTranslatorTestUtility
         {
             public ItemFilterBlockTranslatorTestUtility()

--- a/Filtration.Parser/Services/ItemFilterBlockTranslator.cs
+++ b/Filtration.Parser/Services/ItemFilterBlockTranslator.cs
@@ -47,7 +47,7 @@ namespace Filtration.Parser.Services
             return itemFilterCommentBlock;
         }
 
-        // This method converts a string into a ItemFilterBlock. This is used for pasting ItemFilterBlocks 
+        // This method converts a string into a ItemFilterBlock. This is used for pasting ItemFilterBlocks
         // and reading ItemFilterScripts from a file.
         public IItemFilterBlock TranslateStringToItemFilterBlock(string inputString, IItemFilterScript parentItemFilterScript, string originalString = "", bool initialiseBlockGroupHierarchyBuilder = false)
         {
@@ -216,7 +216,7 @@ namespace Filtration.Parser.Services
                         RemoveExistingBlockItemsOfType<TextColorBlockItem>(block);
 
                         var result = Regex.Matches(trimmedLine, @"([\w\s]*)");
-                        
+
                         var blockItem = new TextColorBlockItem();
                         blockItem.Color = GetColorFromString(result[0].Groups[1].Value);
                         block.BlockItems.Add(blockItem);
@@ -229,7 +229,7 @@ namespace Filtration.Parser.Services
                         RemoveExistingBlockItemsOfType<BackgroundColorBlockItem>(block);
 
                         var result = Regex.Matches(trimmedLine, @"([\w\s]*)");
-                        
+
                         var blockItem = new BackgroundColorBlockItem();
                         blockItem.Color = GetColorFromString(result[0].Groups[1].Value);
                         block.BlockItems.Add(blockItem);
@@ -242,7 +242,7 @@ namespace Filtration.Parser.Services
                         RemoveExistingBlockItemsOfType<BorderColorBlockItem>(block);
 
                         var result = Regex.Matches(trimmedLine, @"([\w\s]*)");
-                        
+
                         var blockItem = new BorderColorBlockItem();
                         blockItem.Color = GetColorFromString(result[0].Groups[1].Value);
                         block.BlockItems.Add(blockItem);
@@ -272,7 +272,7 @@ namespace Filtration.Parser.Services
                         RemoveExistingBlockItemsOfType<CustomSoundBlockItem>(block);
 
                         var match = Regex.Match(trimmedLine, @"\S+\s+(\S+)\s?(\d+)?");
-                        
+
                         if (match.Success)
                         {
                             string firstValue = match.Groups[1].Value;
@@ -341,12 +341,12 @@ namespace Filtration.Parser.Services
                     {
                         // Only ever use the last Icon item encountered as multiples aren't valid.
                         RemoveExistingBlockItemsOfType<MapIconBlockItem>(block);
-                        
+
                         // TODO: Get size, color, shape values programmatically
                         var match = Regex.Match(trimmedLine,
                             @"\S+\s+(0|1|2)\s+(Red|Green|Blue|Brown|White|Yellow)\s+(Circle|Diamond|Hexagon|Square|Star|Triangle)\s*([#]?)(.*)",
                             RegexOptions.IgnoreCase);
-                        
+
                         if (match.Success)
                         {
                             var blockItemValue = new MapIconBlockItem
@@ -355,7 +355,7 @@ namespace Filtration.Parser.Services
                                 Color = EnumHelper.GetEnumValueFromDescription<IconColor>(match.Groups[2].Value),
                                 Shape = EnumHelper.GetEnumValueFromDescription<IconShape>(match.Groups[3].Value)
                             };
-                                
+
                             if(match.Groups[4].Value == "#" && !string.IsNullOrWhiteSpace(match.Groups[5].Value))
                             {
                                 ThemeComponent themeComponent = _masterComponentCollection.AddComponent(ThemeComponentType.Icon, match.Groups[5].Value.Trim(),
@@ -371,10 +371,10 @@ namespace Filtration.Parser.Services
                     {
                         // Only ever use the last BeamColor item encountered as multiples aren't valid.
                         RemoveExistingBlockItemsOfType<PlayEffectBlockItem>(block);
-                        
+
                         // TODO: Get colors programmatically
                         var match = Regex.Match(trimmedLine, @"\S+\s+(Red|Green|Blue|Brown|White|Yellow)\s*(Temp)?", RegexOptions.IgnoreCase);
-                        
+
                         if (match.Success)
                         {
                             var blockItemValue = new PlayEffectBlockItem
@@ -394,8 +394,8 @@ namespace Filtration.Parser.Services
                         RemoveExistingBlockItemsOfType<SoundBlockItem>(block);
                         RemoveExistingBlockItemsOfType<PositionalSoundBlockItem>(block);
 
-                        var match = Regex.Match(trimmedLine, @"\S+\s+""(\S+)""");
-                        
+	                    var match = Regex.Match(trimmedLine, @"\S+\s+""([^\*\<\>\?|]+)""");
+
                         if (match.Success)
                         {
                             var blockItemValue = new CustomSoundBlockItem
@@ -523,7 +523,7 @@ namespace Filtration.Parser.Services
         private static void AddNumericFilterPredicateItemToBlockItems<T>(IItemFilterBlock block, string inputString) where T : NumericFilterPredicateBlockItem
         {
             var blockItem = Activator.CreateInstance<T>();
-            
+
             SetNumericFilterPredicateFromString(blockItem.FilterPredicate, inputString);
             block.BlockItems.Add(blockItem);
         }
@@ -597,7 +597,7 @@ namespace Filtration.Parser.Services
                     case "SetTextColor":
                     {
                         var result = Regex.Matches(trimmedLine, @"([\w\s]*)");
-                        
+
                         var blockItem = new TextColorBlockItem();
                         blockItem.Color = GetColorFromString(result[0].Groups[1].Value);
                         if(_masterComponentCollection != null && !string.IsNullOrWhiteSpace(blockComment))
@@ -612,7 +612,7 @@ namespace Filtration.Parser.Services
                     case "SetBackgroundColor":
                     {
                         var result = Regex.Matches(trimmedLine, @"([\w\s]*)");
-                        
+
                         var blockItem = new BackgroundColorBlockItem();
                         blockItem.Color = GetColorFromString(result[0].Groups[1].Value);
                         if(_masterComponentCollection != null && !string.IsNullOrWhiteSpace(blockComment))
@@ -627,7 +627,7 @@ namespace Filtration.Parser.Services
                     case "SetBorderColor":
                     {
                         var result = Regex.Matches(trimmedLine, @"([\w\s]*)");
-                        
+
                         var blockItem = new BorderColorBlockItem();
                         blockItem.Color = GetColorFromString(result[0].Groups[1].Value);
                         if(_masterComponentCollection != null && !string.IsNullOrWhiteSpace(blockComment))
@@ -653,10 +653,10 @@ namespace Filtration.Parser.Services
                         blockItems.Add(blockItem);
                         break;
                     }
-                } 
+                }
             }
         }
-        
+
         private void AddBlockGroupToBlock(IItemFilterBlock block, string inputString)
         {
             var blockGroupText = GetTextAfterFirstComment(inputString);
@@ -741,7 +741,7 @@ namespace Filtration.Parser.Services
             // Remove trailing newline
             return commentWithHashes.TrimEnd('\r', '\n');
         }
-        
+
         // This method converts an ItemFilterBlock object into a string. This is used for copying a ItemFilterBlock
         // to the clipboard, and when saving a ItemFilterScript.
         // TODO: Private


### PR DESCRIPTION
This fixes #61 by modifying one regex, with a series of tests being added as well. Everything else is just my editor disagreeing with the whitespace within the two modified files.