### PR TITLE
Improve pasting to support different copy sources

### DIFF
--- a/Filtration.ObjectModel/Commands/ItemFilterScript/PasteMultipleBlocksCommand.cs
+++ b/Filtration.ObjectModel/Commands/ItemFilterScript/PasteMultipleBlocksCommand.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Filtration.ObjectModel.Commands.ItemFilterScript
+{
+    public class PasteMultipleBlocksCommand : IUndoableCommand
+    {
+        private readonly IItemFilterScript _itemFilterScript;
+        private readonly List<IItemFilterBlockBase> _pastedItemFilterBlocks;
+        private readonly IItemFilterBlockBase _addAfterItemFilterBlock;
+
+        public PasteMultipleBlocksCommand(IItemFilterScript itemFilterScript, List<IItemFilterBlockBase> pastedItemFilterBlocks, IItemFilterBlockBase addAfterItemFilterBlock)
+        {
+            _itemFilterScript = itemFilterScript;
+            _pastedItemFilterBlocks = pastedItemFilterBlocks;
+            _addAfterItemFilterBlock = addAfterItemFilterBlock;
+        }
+
+        public void Execute()
+        {
+            if (_addAfterItemFilterBlock != null)
+            {
+                var lastAddedBlock = _addAfterItemFilterBlock;
+                foreach(var block in _pastedItemFilterBlocks)
+                {
+                    _itemFilterScript.ItemFilterBlocks.Insert(_itemFilterScript.ItemFilterBlocks.IndexOf(lastAddedBlock) + 1, block);
+                    lastAddedBlock = block;
+                }
+            }
+            else
+            {
+                foreach (var block in _pastedItemFilterBlocks)
+                {
+                    _itemFilterScript.ItemFilterBlocks.Add(block);
+                }
+            }
+        }
+
+        public void Undo()
+        {
+            foreach (var block in _pastedItemFilterBlocks)
+            {
+                _itemFilterScript.ItemFilterBlocks.Remove(block);
+            }
+        }
+
+        public void Redo() => Execute();
+    }
+}

--- a/Filtration.ObjectModel/Filtration.ObjectModel.csproj
+++ b/Filtration.ObjectModel/Filtration.ObjectModel.csproj
@@ -117,7 +117,7 @@
     <Compile Include="Commands\ItemFilterScript\MoveBlockDownCommand.cs" />
     <Compile Include="Commands\ItemFilterScript\MoveBlockUpCommand.cs" />
     <Compile Include="Commands\ItemFilterScript\MoveBlockToTopCommand.cs" />
-    <Compile Include="Commands\ItemFilterScript\PasteSectionCommand.cs" />
+    <Compile Include="Commands\ItemFilterScript\PasteMultipleBlocksCommand.cs" />
     <Compile Include="Commands\ItemFilterScript\RemoveSectionCommand.cs" />
     <Compile Include="Commands\ItemFilterScript\SetScriptDescriptionCommand.cs" />
     <Compile Include="Commands\ItemFilterScript\RemoveBlockCommand.cs" />

--- a/Filtration.ObjectModel/ThemeEditor/ThemeComponentCollection.cs
+++ b/Filtration.ObjectModel/ThemeEditor/ThemeComponentCollection.cs
@@ -93,5 +93,10 @@ namespace Filtration.ObjectModel.ThemeEditor
                 Items.Count(c => c.ComponentName == componentName && c.ComponentType == componentType);
             return componentCount > 0;
         }
+
+        public bool ComponentExists(ThemeComponent themeComponent)
+        {
+            return ComponentExists(themeComponent.ComponentType, themeComponent.ComponentName);
+        }
     }
 }

--- a/Filtration.Parser.Interface/Services/IItemFilterScriptTranslator.cs
+++ b/Filtration.Parser.Interface/Services/IItemFilterScriptTranslator.cs
@@ -5,6 +5,7 @@ namespace Filtration.Parser.Interface.Services
     public interface IItemFilterScriptTranslator
     {
         IItemFilterScript TranslateStringToItemFilterScript(string inputString);
+        IItemFilterScript TranslatePastedStringToItemFilterScript(string inputString, bool blockGroupsEnabled);
         string TranslateItemFilterScriptToString(IItemFilterScript script);
     }
 }

--- a/Filtration.Parser/Services/ItemFilterScriptTranslator.cs
+++ b/Filtration.Parser/Services/ItemFilterScriptTranslator.cs
@@ -210,7 +210,18 @@ namespace Filtration.Parser.Services
             _blockGroupHierarchyBuilder.Cleanup();
             return script;
         }
-        
+
+        public IItemFilterScript TranslatePastedStringToItemFilterScript(string inputString, bool blockGroupsEnabled)
+        {
+            //Remove old disabled tags to prevent messagebox on paste
+            inputString = Regex.Replace(inputString, @"#Disabled\sBlock\s(Start|End).*?\n", "");
+            inputString = (inputString.EndsWith("\n#Disabled Block End")) ? inputString.Substring(0, inputString.Length - 19) : inputString;
+
+            inputString = (blockGroupsEnabled ? "# EnableBlockGroups" : "#") + Environment.NewLine + Environment.NewLine + inputString;
+
+            return TranslateStringToItemFilterScript(inputString);
+        }
+
         private static LinkedList<ItemFilterBlockBoundary> IdentifyBlockBoundaries(string inputString, List<bool> inBlock)
         {
             var blockBoundaries = new LinkedList<ItemFilterBlockBoundary>();

--- a/Filtration/ViewModels/ToolPanes/BlockGroupBrowserViewModel.cs
+++ b/Filtration/ViewModels/ToolPanes/BlockGroupBrowserViewModel.cs
@@ -40,6 +40,11 @@ namespace Filtration.ViewModels.ToolPanes
                         OnShowAdvancedToggled(message.Content);
                         break;
                     }
+                    case "BlockGroupsChanged":
+                    {
+                        BlockGroupViewModels = RebuildBlockGroupViewModels(message.Content);
+                        break;
+                    }
                 }
             });
 


### PR DESCRIPTION
- Theme components of copied blocks are also added
- Block groups (if enabled in the target script) are also added

Now blocks or even whole scripts can be pasted whether it is copied from filtration or a text editor.