### PR TITLE
Preserve UI states and last active document

### DIFF
--- a/Filtration/Properties/Settings.Designer.cs
+++ b/Filtration/Properties/Settings.Designer.cs
@@ -121,5 +121,125 @@ namespace Filtration.Properties {
                 return ((string)(this["UpdateDataUrl"]));
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool ShowSectionBrowser
+        {
+            get
+            {
+                return ((bool)(this["ShowSectionBrowser"]));
+            }
+            set
+            {
+                this["ShowSectionBrowser"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ShowBlockGroupBrowser
+        {
+            get
+            {
+                return ((bool)(this["ShowBlockGroupBrowser"]));
+            }
+            set
+            {
+                this["ShowBlockGroupBrowser"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ShowBlockOutputPreview
+        {
+            get
+            {
+                return ((bool)(this["ShowBlockOutputPreview"]));
+            }
+            set
+            {
+                this["ShowBlockOutputPreview"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ShowAdvanced
+        {
+            get
+            {
+                return ((bool)(this["ShowAdvanced"]));
+            }
+            set
+            {
+                this["ShowAdvanced"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Normal")]
+        public global::System.Windows.WindowState WindowState
+        {
+            get
+            {
+                return ((global::System.Windows.WindowState)(this["WindowState"]));
+            }
+            set
+            {
+                this["WindowState"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("960")]
+        public int WindowWidth
+        {
+            get
+            {
+                return ((int)(this["WindowWidth"]));
+            }
+            set
+            {
+                this["WindowWidth"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("720")]
+        public int WindowHeight
+        {
+            get
+            {
+                return ((int)(this["WindowHeight"]));
+            }
+            set
+            {
+                this["WindowHeight"] = value;
+            }
+        }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("")]
+        public string LastActiveDocument
+        {
+            get
+            {
+                return ((string)(this["LastActiveDocument"]));
+            }
+            set
+            {
+                this["LastActiveDocument"] = value;
+            }
+        }
     }
 }

--- a/Filtration/ViewModels/AvalonDockWorkspaceViewModel.cs
+++ b/Filtration/ViewModels/AvalonDockWorkspaceViewModel.cs
@@ -9,6 +9,7 @@ using Filtration.ThemeEditor.ViewModels;
 using Filtration.ViewModels.ToolPanes;
 using GalaSoft.MvvmLight;
 using GalaSoft.MvvmLight.Messaging;
+using Filtration.Properties;
 
 namespace Filtration.ViewModels
 {
@@ -74,6 +75,7 @@ namespace Filtration.ViewModels
                 if (value.IsScript)
                 {
                     _activeScriptViewModel = (IItemFilterScriptViewModel) value;
+                    Settings.Default.LastActiveDocument = _activeScriptViewModel.Script.FilePath;
                 }
                 else if (value.IsTheme)
                 {

--- a/Filtration/ViewModels/ItemFilterScriptViewModel.cs
+++ b/Filtration/ViewModels/ItemFilterScriptViewModel.cs
@@ -21,6 +21,7 @@ using Filtration.ObjectModel.BlockItemTypes;
 using Filtration.ObjectModel.Commands;
 using Filtration.ObjectModel.Commands.ItemFilterScript;
 using Filtration.Parser.Interface.Services;
+using Filtration.Properties;
 using Filtration.Services;
 using Filtration.ViewModels.Factories;
 using GalaSoft.MvvmLight.CommandWpf;
@@ -125,6 +126,7 @@ namespace Filtration.ViewModels
             _clipboardService = clipboardService;
             _blockGroupHierarchyBuilder = blockGroupHierarchyBuilder;
             _itemFilterBlockViewModels = new ObservableCollection<IItemFilterBlockViewModelBase>();
+            _showAdvanced = Settings.Default.ShowAdvanced;
 
             _avalonDockWorkspaceViewModel.ActiveDocumentChanged += (s, e) =>
             {
@@ -451,6 +453,7 @@ namespace Filtration.ViewModels
                 _showAdvanced = value;
                 RaisePropertyChanged();
                 RaisePropertyChanged(nameof(ViewItemFilterBlockViewModels));
+                Settings.Default.ShowAdvanced = value;
             }
         }
 

--- a/Filtration/ViewModels/MainWindowViewModel.cs
+++ b/Filtration/ViewModels/MainWindowViewModel.cs
@@ -14,6 +14,7 @@ using Filtration.Interface;
 using Filtration.ObjectModel.Enums;
 using Filtration.ObjectModel.ThemeEditor;
 using Filtration.Parser.Interface.Services;
+using Filtration.Properties;
 using Filtration.Repositories;
 using Filtration.Services;
 using Filtration.ThemeEditor.Messages;
@@ -50,6 +51,9 @@ namespace Filtration.ViewModels
         private readonly IMessageBoxService _messageBoxService;
         private readonly IClipboardService _clipboardService;
         private bool _showLoadingBanner;
+        private WindowState _windowState;
+        private int _windowWidth;
+        private int _windowHeight;
 
         public MainWindowViewModel(IItemFilterScriptRepository itemFilterScriptRepository,
                                    IItemFilterScriptTranslator itemFilterScriptTranslator,
@@ -70,6 +74,9 @@ namespace Filtration.ViewModels
             _themeService = themeService;
             _messageBoxService = messageBoxService;
             _clipboardService = clipboardService;
+            _windowState = Settings.Default.WindowState;
+            _windowWidth = Settings.Default.WindowWidth;
+            _windowHeight = Settings.Default.WindowHeight;
 
             NewScriptCommand = new RelayCommand(OnNewScriptCommand);
             CopyScriptCommand = new RelayCommand(OnCopyScriptCommand, () => ActiveDocumentIsScript);
@@ -192,6 +199,11 @@ namespace Filtration.ViewModels
                     }
                 }
             });
+
+            if (!string.IsNullOrWhiteSpace(Settings.Default.LastActiveDocument) && File.Exists(Settings.Default.LastActiveDocument))
+            {
+                LoadScriptAsync(Settings.Default.LastActiveDocument);
+            }
         }
 
         public RelayCommand OpenScriptCommand { get; }
@@ -261,6 +273,45 @@ namespace Filtration.ViewModels
                 var assembly = Assembly.GetExecutingAssembly();
                 var fvi = FileVersionInfo.GetVersionInfo(assembly.Location);
                 return "Filtration v" + fvi.FileMajorPart + "." +  fvi.FileMinorPart;
+            }
+        }
+
+        public WindowState WindowState
+        {
+            get => _windowState;
+            set
+            {
+                _windowState = value;
+                if(value != WindowState.Minimized)
+                {
+                    Settings.Default.WindowState = value;
+                }
+            }
+        }
+
+        public int WindowWidth
+        {
+            get => _windowWidth;
+            set
+            {
+                _windowWidth = value;
+                if (WindowState == WindowState.Normal)
+                {
+                    Settings.Default.WindowWidth = value;
+                }
+            }
+        }
+
+        public int WindowHeight
+        {
+            get => _windowHeight;
+            set
+            {
+                _windowHeight = value;
+                if (WindowState == WindowState.Normal)
+                {
+                    Settings.Default.WindowHeight = value;
+                }
             }
         }
 
@@ -574,6 +625,7 @@ namespace Filtration.ViewModels
 
         private void OnCloseDocumentCommand()
         {
+            Settings.Default.LastActiveDocument = "";
             _avalonDockWorkspaceViewModel.ActiveDocument.Close();
         }
 

--- a/Filtration/ViewModels/ToolPanes/BlockGroupBrowserViewModel.cs
+++ b/Filtration/ViewModels/ToolPanes/BlockGroupBrowserViewModel.cs
@@ -32,8 +32,6 @@ namespace Filtration.ViewModels.ToolPanes
             icon.EndInit();
             IconSource = icon;
 
-            IsVisible = false;
-
             Messenger.Default.Register<NotificationMessage<bool>>(this, message =>
             {
                 switch (message.Notification)

--- a/Filtration/ViewModels/ToolPanes/BlockOutputPreviewViewModel.cs
+++ b/Filtration/ViewModels/ToolPanes/BlockOutputPreviewViewModel.cs
@@ -26,8 +26,6 @@ namespace Filtration.ViewModels.ToolPanes
             icon.EndInit();
             IconSource = icon;
 
-            IsVisible = false;
-
             Messenger.Default.Register<NotificationMessage>(this, message =>
             {
                 switch (message.Notification)

--- a/Filtration/ViewModels/ToolPanes/ToolViewModel.cs
+++ b/Filtration/ViewModels/ToolPanes/ToolViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Filtration.Common.ViewModels;
+using Filtration.Properties;
 
 namespace Filtration.ViewModels.ToolPanes
 {
@@ -14,6 +15,19 @@ namespace Filtration.ViewModels.ToolPanes
         {
             Name = name;
             Title = name;
+
+            switch (Name)
+            {
+                case "Section Browser":
+                    IsVisible = Settings.Default.ShowSectionBrowser;
+                    break;
+                case "Block Group Browser":
+                    IsVisible = Settings.Default.ShowBlockGroupBrowser;
+                    break;
+                case "Block Output Preview":
+                    IsVisible = Settings.Default.ShowBlockOutputPreview;
+                    break;
+            }
         }
 
         public string Name { get; private set; }
@@ -27,6 +41,18 @@ namespace Filtration.ViewModels.ToolPanes
                 if (_isVisible != value)
                 {
                     _isVisible = value;
+                    switch(Name)
+                    {
+                        case "Section Browser":
+                            Settings.Default.ShowSectionBrowser = value;
+                            break;
+                        case "Block Group Browser":
+                            Settings.Default.ShowBlockGroupBrowser = value;
+                            break;
+                        case "Block Output Preview":
+                            Settings.Default.ShowBlockOutputPreview = value;
+                            break;
+                    }
                     RaisePropertyChanged();
                 }
             }

--- a/Filtration/Views/MainWindow.xaml
+++ b/Filtration/Views/MainWindow.xaml
@@ -12,7 +12,7 @@
         xmlns:utility="clr-namespace:Filtration.Utility"
         mc:Ignorable="d"
         d:DataContext="{d:DesignInstance Type=viewModels:MainWindowViewModel}"
-        Title="{Binding WindowTitle}" Height="762" Width="1126" IsIconVisible="True"
+        Title="{Binding WindowTitle}" Height="{Binding WindowHeight, Mode=TwoWay}" Width="{Binding WindowWidth, Mode=TwoWay}" IsIconVisible="True" WindowState="{Binding WindowState}"
         Closing="MainWindow_OnClosing" Drop="MainWindow_OnDrop" AllowDrop="True">
 
     <fluent:RibbonWindow.InputBindings>


### PR DESCRIPTION
Related #12 and #13 
Preserved states:

- Main windows state (maximixed/normal)
- Main window size
- ToolPane states
- Show Advanced toggle

Also saves the path of last _active_ filter and opens on launch if it exists