### PR TITLE
Increase HasExplicitMod limit to 8

### DIFF
--- a/Filtration.ObjectModel/BlockItemTypes/HasExplicitModBlockItem.cs
+++ b/Filtration.ObjectModel/BlockItemTypes/HasExplicitModBlockItem.cs
@@ -7,7 +7,7 @@ namespace Filtration.ObjectModel.BlockItemTypes
     public class HasExplicitModBlockItem : StringListBlockItem
     {
         public override string PrefixText => "HasExplicitMod";
-        public override int MaximumAllowed => 1;
+        public override int MaximumAllowed => 8;
         public override string DisplayHeading => "Has Explicit Mod";
 
         public override string SummaryText


### PR DESCRIPTION
Related #81 

There doesn't seem to be a limit. However since all of the rules are combined with 'and', more than 6 provides no use.

Edited to make it 8, forgot maps.