### PR TITLE
Add a few missing item classes.

### DIFF
--- a/Filtration/Resources/ItemClasses.txt
+++ b/Filtration/Resources/ItemClasses.txt
@@ -23,12 +23,13 @@ Labyrinth Item
 Labyrinth Map Item
 Labyrinth Trinket
 Large Relics
-Leaguestone
+Leaguestones
 Life Flasks
 Maces
 Mana Flasks
 Map Fragments
 Maps
+Medium Relics
 Misc Map Items
 One Hand Axes
 One Hand Maces
@@ -37,9 +38,11 @@ Pantheon Soul
 Piece
 Quest Items
 Quivers
+Relics
 Rings
 Sceptres
 Shields
+Small Relics
 Stackable Currency
 Staves
 Support Skill Gems


### PR DESCRIPTION
Essentially just the relic classes, which we already had one of. I've intentionally left `Critical Utility Flasks`, `Microtransactions` and `Hideout Doodads` off the list.