### PR TITLE
Fix null reference error on section search

### DIFF
--- a/Filtration/ViewModels/ItemFilterScriptViewModel.cs
+++ b/Filtration/ViewModels/ItemFilterScriptViewModel.cs
@@ -578,6 +578,9 @@ namespace Filtration.ViewModels
 
         public bool CanModifyBlock(IItemFilterBlockViewModelBase itemFilterBlock)
         {
+            if (itemFilterBlock == null)
+                return false;
+
             if (itemFilterBlock is IItemFilterBlockViewModel)
                 return true;
 


### PR DESCRIPTION
To recreate:

- Search sections
- Choose one of results
- Search again with something that results in previous selected section being filtered out