### PR TITLE
Add simple auto-save feature

### DIFF
--- a/Filtration/Converters/AutosaveIntervalConverter.cs
+++ b/Filtration/Converters/AutosaveIntervalConverter.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Globalization;
+using System.Windows.Data;
+using Filtration.Enums;
+
+namespace Filtration.Converters
+{
+    public class IntToAutosaveIntervalConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (AutosaveInterval)(int)value;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            return (int)(AutosaveInterval)value;
+        }
+    }
+}

--- a/Filtration/Enums/AutosaveInterval.cs
+++ b/Filtration/Enums/AutosaveInterval.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel;
+
+namespace Filtration.Enums
+{
+    internal enum AutosaveInterval
+    {
+        [Description("Never")]
+        Never = -1,
+        [Description("5 sec")]
+        FiveSec = 5 * 1000,
+        [Description("10 sec")]
+        TenSec = 10 * 1000,
+        [Description("30 sec")]
+        ThirtySec = 30 * 1000,
+        [Description("1 min")]
+        OneMin = 60 * 1000,
+        [Description("5 min")]
+        FiveMin = 5 * 60 * 1000
+    }
+}

--- a/Filtration/Filtration.csproj
+++ b/Filtration/Filtration.csproj
@@ -212,10 +212,12 @@
     <Compile Include="Converters\BlockItemToRemoveEnabledVisibilityConverter.cs" />
     <Compile Include="Converters\DisabledDefaultSoundConverter.cs" />
     <Compile Include="Converters\DisabledDefaultSoundTooltipConverter.cs" />
+    <Compile Include="Converters\AutosaveIntervalConverter.cs" />
     <Compile Include="Converters\MinimapIconToCroppedBitmapConverter.cs" />
     <Compile Include="Converters\HashSignRemovalConverter.cs" />
     <Compile Include="Converters\ItemRarityConverter.cs" />
     <Compile Include="Converters\TreeViewMarginConverter.cs" />
+    <Compile Include="Enums\AutosaveInterval.cs" />
     <Compile Include="Enums\UpdateSource.cs" />
     <Compile Include="Models\UpdateData.cs" />
     <Compile Include="Properties\Annotations.cs" />

--- a/Filtration/Properties/Settings.Designer.cs
+++ b/Filtration/Properties/Settings.Designer.cs
@@ -166,5 +166,20 @@ namespace Filtration.Properties {
                 this["BlocksExpandedOnOpen"] = value;
             }
         }
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("60000")]
+        public int AutosaveInterval
+        {
+            get
+            {
+                return ((int)(this["AutosaveInterval"]));
+            }
+            set
+            {
+                this["AutosaveInterval"] = value;
+            }
+        }
     }
 }

--- a/Filtration/ViewModels/DesignTime/DesignTimeSettingsPageViewModel.cs
+++ b/Filtration/ViewModels/DesignTime/DesignTimeSettingsPageViewModel.cs
@@ -21,5 +21,8 @@ namespace Filtration.ViewModels.DesignTime
         }
 
         public bool DownloadPrereleaseUpdates { get; set; }
+        public int AutosaveInterval { get; set; }
+
+        public void SetAutosaveTimer (System.Timers.Timer timer) { }
     }
 }

--- a/Filtration/ViewModels/MainWindowViewModel.cs
+++ b/Filtration/ViewModels/MainWindowViewModel.cs
@@ -210,6 +210,24 @@ namespace Filtration.ViewModels
                 }
             });
 
+            System.Timers.Timer timer = new System.Timers.Timer();
+            timer.Elapsed += (sender, e) => OnTimedEvent(sender, e, this);
+            timer.Interval = Settings.Default.AutosaveInterval > 0 ? Settings.Default.AutosaveInterval : double.MaxValue;
+            timer.Enabled = Settings.Default.AutosaveInterval > 0;
+            settingsPageViewModel.SetAutosaveTimer(timer);
+        }
+
+        private static void OnTimedEvent(Object source, System.Timers.ElapsedEventArgs e, MainWindowViewModel mainWindowViewModel)
+        {
+            mainWindowViewModel.AutoSave();
+        }
+
+        public void AutoSave()
+        {
+            foreach (var doc in _avalonDockWorkspaceViewModel.OpenDocuments.OfType<IItemFilterScriptViewModel>().Where(doc => doc.IsDirty && doc.IsScript && !doc.IsFilenameFake && doc.Autosave))
+            {
+                doc.SaveAsync();
+            }
         }
 
         public RelayCommand OpenScriptCommand { get; }

--- a/Filtration/ViewModels/SettingsPageViewModel.cs
+++ b/Filtration/ViewModels/SettingsPageViewModel.cs
@@ -13,11 +13,15 @@ namespace Filtration.ViewModels
         bool BlocksExpandedOnOpen { get; set; }
         bool DownloadPrereleaseUpdates { get; set; }
         bool ExtraLineBetweenBlocks { get; set; }
+        int AutosaveInterval { get; set; }
+
+        void SetAutosaveTimer(System.Timers.Timer timer);
     }
 
     internal class SettingsPageViewModel : ViewModelBase, ISettingsPageViewModel
     {
         private readonly IItemFilterScriptDirectoryService _itemFilterScriptDirectoryService;
+        private System.Timers.Timer _autosaveTimer;
 
         public SettingsPageViewModel(IItemFilterScriptDirectoryService itemFilterScriptDirectoryService)
         {
@@ -45,6 +49,36 @@ namespace Filtration.ViewModels
         {
             get => Settings.Default.ExtraLineBetweenBlocks;
             set => Settings.Default.ExtraLineBetweenBlocks = value;
+        }
+
+        public int AutosaveInterval
+        {
+            get => Settings.Default.AutosaveInterval;
+            set
+            {
+                Settings.Default.AutosaveInterval = value;
+                if (_autosaveTimer != null)
+                {
+                    if (value < 0)
+                    {
+                        _autosaveTimer.Stop();
+                    }
+                    else if (_autosaveTimer.Interval != value)
+                    {
+                        _autosaveTimer.Stop();
+                        _autosaveTimer.Interval = value;
+                        _autosaveTimer.Start();
+                    }
+                }
+            }
+        }
+
+        public void SetAutosaveTimer(System.Timers.Timer timer)
+        {
+            if (_autosaveTimer == null)
+            {
+                _autosaveTimer = timer;
+            }
         }
 
         private void OnSetItemFilterScriptDirectoryCommand()

--- a/Filtration/Views/SettingsPageView.xaml
+++ b/Filtration/Views/SettingsPageView.xaml
@@ -1,11 +1,17 @@
-﻿<UserControl x:Class="Filtration.Views.SettingsPageView"
+﻿<UserControl
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:designTime="clr-namespace:Filtration.ViewModels.DesignTime"
+        xmlns:extensions="clr-namespace:Filtration.Common.Extensions;assembly=Filtration.Common"
+        xmlns:enums="clr-namespace:Filtration.Enums"
+        xmlns:Converters="clr-namespace:Filtration.Converters" x:Class="Filtration.Views.SettingsPageView"
         mc:Ignorable="d" d:DesignWidth="1200" d:DesignHeight="400"
-        d:DataContext="{d:DesignInstance Type=designTime:DesignTimeSettingsPageViewModel, IsDesignTimeCreatable=True}">
+        d:DataContext="{d:DesignInstance IsDesignTimeCreatable=True, Type={x:Type designTime:DesignTimeSettingsPageViewModel}}">
+    <UserControl.Resources>
+        <Converters:IntToAutosaveIntervalConverter x:Key="IntToAutosaveIntervalConverter"/>
+    </UserControl.Resources>
     <Border BorderBrush="Black" BorderThickness="1">
         <DockPanel Margin="10" MaxWidth="600" HorizontalAlignment="Left">
             <Grid DockPanel.Dock="Bottom">
@@ -27,7 +33,7 @@
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />
                     </Grid.RowDefinitions>
-                    <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center">Default Filter Directory:</TextBlock>
+                    <TextBlock Grid.Row="0" Grid.Column="0" VerticalAlignment="Center"><Run Text="Default Filter Directory:"/></TextBlock>
                     <Grid Grid.Row="0" Grid.Column="2" Height="40" Width="300">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
@@ -35,15 +41,20 @@
                         </Grid.ColumnDefinitions>
                         <TextBlock Grid.Column="0" Text="{Binding DefaultFilterDirectory}" TextWrapping="Wrap" VerticalAlignment="Center" />
                         <Button Grid.Column="1" Margin="5,0,0,0" Width="30" Height="30" Command="{Binding SetItemFilterScriptDirectoryCommand}">
-                            <ContentControl Content="{StaticResource OpenIcon}" Width="16" Height="16"></ContentControl>
+                            <ContentControl Content="{StaticResource OpenIcon}" Width="16" Height="16"/>
                         </Button>
                     </Grid>
-                    <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center">Add blank line between blocks when saving</TextBlock>
+                    <TextBlock Grid.Row="2" Grid.Column="0" VerticalAlignment="Center"><Run Text="Add blank line between blocks when saving"/></TextBlock>
                     <CheckBox Grid.Row="2" Grid.Column="2" IsChecked="{Binding ExtraLineBetweenBlocks}"  />
-                    <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center">Download pre-release updates (use with caution)</TextBlock>
+                    <TextBlock Grid.Row="3" Grid.Column="0" VerticalAlignment="Center"><Run Text="Download pre-release updates (use with caution)"/></TextBlock>
                     <CheckBox Grid.Row="3" Grid.Column="2" IsChecked="{Binding DownloadPrereleaseUpdates}"  />
-                    <TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Center">Auto-expand all sections when opening scripts</TextBlock>
+                    <TextBlock Grid.Row="4" Grid.Column="0" VerticalAlignment="Center"><Run Text="Auto-expand all sections when opening scripts"/></TextBlock>
                     <CheckBox Grid.Row="4" Grid.Column="2" IsChecked="{Binding BlocksExpandedOnOpen}"  />
+                    <TextBlock Grid.Row="5" Grid.Column="0" VerticalAlignment="Center"><Run Text="Auto-save interval"/></TextBlock>
+                    <ComboBox Grid.Row="5" Grid.Column="2"  ItemsSource="{Binding Source={extensions:Enumeration {x:Type enums:AutosaveInterval}}}"
+                                                              DisplayMemberPath="Description"
+                                                              SelectedValue="{Binding AutosaveInterval, Converter={StaticResource IntToAutosaveIntervalConverter}}"
+                                                              SelectedValuePath="Value" />
                 </Grid>
             </Grid>
         </DockPanel>


### PR DESCRIPTION
- Added simple auto-save feature that allows changing interval through settings
- Changed unused theme component check to prevent propmting same components again and again

Here are some design choices i made (that are of course open to discussion):
- Default auto-save interval is 1 minute
- Only opened scripts are auto-saved. New scripts and themes aren't.
- Auto-saving stops for a file until user saves himself if user choses not to save after being prompted with unused themes. This is to prevent same happening again and again. Auto-save continues once users saves file manually.