### PR TITLE
Change default border color to transparent

### DIFF
--- a/Filtration.ObjectModel/ItemFilterBlock.cs
+++ b/Filtration.ObjectModel/ItemFilterBlock.cs
@@ -279,7 +279,7 @@ namespace Filtration.ObjectModel
             get
             {
                 var borderColorBlockItem = BlockItems.OfType<BorderColorBlockItem>().FirstOrDefault();
-                return borderColorBlockItem?.Color ?? new Color { A = 240, R = 0, G = 0, B = 0 };
+                return borderColorBlockItem?.Color ?? new Color { A = 0, R = 255, G = 255, B = 255 };
             }
         }
 


### PR DESCRIPTION
I recently realized that game doesn't show any borders when it isn't defined. However, unless my memory is betraying (hah!) me this league, this wasn't the case before. So it might be a recent change or even a bug. But since it is something easy to change, I suggest we change it.