### PR TITLE
Fix Show/Hide parsing

### DIFF
--- a/Filtration.Parser.Tests/Services/TestItemFilterScriptTranslator.cs
+++ b/Filtration.Parser.Tests/Services/TestItemFilterScriptTranslator.cs
@@ -322,7 +322,13 @@ namespace Filtration.Parser.Tests.Services
                                   Environment.NewLine +
                                   "Show" + Environment.NewLine +
                                   "   ItemLevel > 20" + Environment.NewLine +
-                                  "    SetTextColor 255 255 0";
+                                  "    SetTextColor 255 255 0" + Environment.NewLine +
+                                  Environment.NewLine +
+                                  "#Show $Recipes->Glassblower->15% %D1" + Environment.NewLine +
+                                  "#    SetTextColor 255 255 0" + Environment.NewLine +
+                                  Environment.NewLine +
+                                  "#Hide simple text without any special character" + Environment.NewLine +
+                                  "#    SetTextColor 255 255 0";
 
 
             var blockTranslator = new ItemFilterBlockTranslator(Mock.Of<IBlockGroupHierarchyBuilder>());
@@ -332,15 +338,21 @@ namespace Filtration.Parser.Tests.Services
             var result = translator.TranslateStringToItemFilterScript(testInputScript);
 
             // Assert
-            Assert.AreEqual(3, result.ItemFilterBlocks.Count);
+            Assert.AreEqual(5, result.ItemFilterBlocks.Count);
 
             var firstBlock = result.ItemFilterBlocks.OfType<ItemFilterBlock>().First();
             var secondBlock = result.ItemFilterBlocks.OfType<ItemFilterBlock>().Skip(1).First();
             var thirdBlock = result.ItemFilterBlocks.OfType<ItemFilterBlock>().Skip(2).First();
+            var fourthBlock = result.ItemFilterBlocks.OfType<ItemFilterBlock>().Skip(3).First();
+            var fifthBlock = result.ItemFilterBlocks.OfType<ItemFilterBlock>().Skip(4).First();
 
             Assert.AreEqual(3, firstBlock.BlockItems.Count);
             Assert.AreEqual(5, secondBlock.BlockItems.Count);
             Assert.AreEqual(3, thirdBlock.BlockItems.Count);
+            Assert.AreEqual(2, fourthBlock.BlockItems.Count);
+            Assert.AreEqual(2, fifthBlock.BlockItems.Count);
+            Assert.AreEqual(false, fourthBlock.Enabled);
+            Assert.AreEqual(false, fifthBlock.Enabled);
         }
 
         [Test]

--- a/Filtration.Parser/Services/ItemFilterScriptTranslator.cs
+++ b/Filtration.Parser/Services/ItemFilterScriptTranslator.cs
@@ -61,8 +61,7 @@ namespace Filtration.Parser.Services
                 lines[i] = lines[i].Trim();
                 if(!lines[i].StartsWith("#"))
                 {
-                    string curLine = Regex.Replace(lines[i], @"\s+", "");
-                    if ((curLine.StartsWith("Show") || curLine.StartsWith("Hide")) && (curLine.Length == 4 || curLine[4] == '#')) // found
+                    if ((lines[i].StartsWith("Show") || lines[i].StartsWith("Hide")) && (lines[i].Length == 4 || lines[i][4] == ' ')) // found
                     {
                         inBlock[i] = true;
                         break;
@@ -98,8 +97,8 @@ namespace Filtration.Parser.Services
             {
                 if (!inDisabledBlock && lines[i].StartsWith("#"))
                 {
-                    string curLine = Regex.Replace(lines[i].Substring(1), @"\s+", "");
-                    if ((curLine.StartsWith("Show") || curLine.StartsWith("Hide")) && (curLine.Length == 4 || curLine[4] == '#') && !inBlock[i])
+                    string curLine = lines[i].Substring(1).Trim();
+                    if ((curLine.StartsWith("Show") || curLine.StartsWith("Hide")) && (curLine.Length == 4 || curLine[4] == ' ') && !inBlock[i])
                     {
                         inDisabledBlock = true;
                         lines[i] = lines[i].Substring(1).TrimStart(' ');


### PR DESCRIPTION
As pointed out in the forum in [here](https://www.pathofexile.com/forum/view-thread/1287447/page/29#p21760930) game accepts any Show/Hide starts as valid as long as it is followed by a space.